### PR TITLE
changed right click expand / collapse

### DIFF
--- a/src/CLMS/xiNET/CrosslinkViewerBB.js
+++ b/src/CLMS/xiNET/CrosslinkViewerBB.js
@@ -74,6 +74,15 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
               "<li class='expand_residuesShown'>Expand (residues shown)</li>" +
             "</ul>");
 
+        var contextMenu = d3.select(".custom-menu").node();
+        contextMenu.onmouseout =  function(evt) {
+            var e = event.toElement || event.relatedTarget;
+            if (e.parentNode == this || e == this) {
+               return;
+            }
+            d3.select(this).style("display", "none");
+        };
+
         //hack to take out pan/select option in firefox
         if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1){
             // Do Firefox-related activities
@@ -97,13 +106,13 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
         var userAgent = navigator.userAgent;
 
         // if (userAgent.indexOf("MSIE") > -1 || userAgent.indexOf("Trident") > -1  || userAgent.indexOf("Edge") > -1) {
-            document.oncontextmenu = function(evt) {
-                if (evt.preventDefault) { // necessary for addEventListener, works with traditional
-                    evt.preventDefault();
-                }
-                evt.returnValue = false;    // necessary for attachEvent, works with traditional
-                return false;           // works with traditional, not with attachEvent or addEventListener
-            }
+            // document.oncontextmenu = function(evt) {
+            //     if (evt.preventDefault) { // necessary for addEventListener, works with traditional
+            //         evt.preventDefault();
+            //     }
+            //     evt.returnValue = false;    // necessary for attachEvent, works with traditional
+            //     return false;           // works with traditional, not with attachEvent or addEventListener
+            // }
         // } else {
         //         this.svgElement.oncontextmenu = function(evt) {
         //         if (evt.preventDefault) {     // necessary for addEventListener, works with traditional

--- a/src/CLMS/xiNET/CrosslinkViewerBB.js
+++ b/src/CLMS/xiNET/CrosslinkViewerBB.js
@@ -22,7 +22,7 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
     //static var's signifying Controller's status
     STATES: {MOUSE_UP:0, SELECT_PAN:1, DRAGGING:2, ROTATING:3, SELECTING: 6},
             /*SCALING_PROTEIN: 4, SCALING_ALL_PROTEINS: 5,*/
-    
+
     expandOrCollapseProtein: function (){
         d3.select("#container-menu").style("display", "none");
         if (this.contextMenuProt.form == 1) {
@@ -67,7 +67,7 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
 
         d3.select(this.el).html(
             "<ul class='custom-menu' id='container-menu'>" +
-              "<li class='expand_collapse'>Expand or Collapse</li>" +
+              "<li class='expand_collapse'>Collapse</li>" +
               "<li class='expand_x1'>Expand (scale x 1)</li>" +
               "<li class='expand_x2'>Expand (scale x 2)</li>" +
               "<li class='expand_x4'>Expand (scale x 4)</li>" +
@@ -582,19 +582,14 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
                 if (!(this.state === this.STATES.DRAGGING || this.state === this.STATES.ROTATING)) { //not dragging or rotating
                         if (this.dragElement.x) { //if the thing is a protein
                             if (rightclick) {
-                                //if (evt.ctrlKey || evt.shiftKey) {
-                                    //this.dragElement.switchStickScale(c);
+                                if (this.dragElement.form === 0) {
+                                    this.dragElement.setForm(1, c);
+                                } else {
                                     this.model.get("tooltipModel").set("contents", null);
                                     this.contextMenuProt = this.dragElement;
                                     var menu = d3.select("#container-menu")
                                     menu.style("top", evt.pageY + "px").style("left", evt.pageX + "px").style("display", "block");
-                                // }else {
-                                //     if (this.dragElement.form === 1) {
-                                //         this.dragElement.setForm(0, c);
-                                //     } else {
-                                //         this.dragElement.setForm(1, c);
-                                //     }
-                                // }
+                                }
                             } else  {
                                 var add = evt.ctrlKey || evt.shiftKey;
                                 this.model.setSelectedProteins([this.dragElement.participant], add);
@@ -872,7 +867,7 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
         }
         return this;
     },
-	
+
 	// mjg april 18
 	highlightedParticipantsChanged: function () {
         var renderedParticipantArr = CLMS.arrayFromMapValues(this.renderedProteins);
@@ -925,7 +920,7 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
 
         return this;
     },
-    
+
     updateProteinNames: function () {
         var renderedParticipantArr = CLMS.arrayFromMapValues(this.renderedProteins);
         var rpCount = renderedParticipantArr.length;
@@ -935,7 +930,7 @@ CLMS.xiNET.CrosslinkViewer = Backbone.View.extend({
 
         return this;
     },
-        
+
     showLabels: function (show) {
         var renderedParticipantArr = CLMS.arrayFromMapValues(this.renderedProteins);
         var rpCount = renderedParticipantArr.length;


### PR DESCRIPTION
right click on circle just expands, right click on bar shows context menu (as per original suggestion).

context menu should disappear on mouse out

the default context menu is only removed from the proteins in the SVG - I'm not sure this always works but removing it from everything is a big hassle for developers